### PR TITLE
Removed deprecated winbluetooth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ libbluetooth = { version = "0.1", features = ["impl-default"] }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.7", features = ["impl-default", "guiddef", "handleapi", "processthreadsapi", "winbase", "winerror", "winnt", "winsock2", "ws2def"] }
-winbluetooth = { version = "0.1", features = ["impl-default"] }
+winapi = { version = "0.3.8", features = ["impl-default", "guiddef", "handleapi", "processthreadsapi", "winbase", "winerror", "winnt", "winsock2", "ws2def","bthdef","ws2bth"] }

--- a/src/sys/windows/c.rs
+++ b/src/sys/windows/c.rs
@@ -14,9 +14,9 @@ pub use winapi::um::winsock2::{
     SOCKET_ERROR, SOCK_STREAM, SOL_SOCKET, SO_ERROR, SO_RCVTIMEO, SO_REUSEADDR, SO_SNDTIMEO,
     WSADATA, WSAESHUTDOWN, WSAPROTOCOL_INFOW, WSAQUERYSETW, WSA_FLAG_OVERLAPPED,
 };
-pub use winbluetooth::shared::bthdef::{
+pub use winapi::shared::bthdef::{
     GET_NAP, GET_SAP, L2CAP_PROTOCOL_UUID, RFCOMM_PROTOCOL_UUID, SET_NAP_SAP,
 };
-pub use winbluetooth::um::ws2bth::{
+pub use winapi::um::ws2bth::{
     AF_BTH, BTHPROTO_L2CAP, BTHPROTO_RFCOMM, BT_PORT_ANY, SOCKADDR_BTH,
 };


### PR DESCRIPTION
Removed winbluetooth since, as per https://github.com/retep998/winapi-rs/pull/753 it's now integrated in winapi.
The version of winapi was also bumped one minor release to the newest version.
No other changes were neccesary due to precise use imports.